### PR TITLE
Improve scenario module readability and add unit tests

### DIFF
--- a/src/scenario.py
+++ b/src/scenario.py
@@ -1,8 +1,17 @@
-"""Scenario definitions and data loading helpers."""
+"""Scenario definitions and data loading helpers.
+
+This module contains lightweight container classes that bundle together the
+various data inputs used by the optimisation layer of the project.  The goal of
+the refactor is to make the construction of scenarios easier to follow and to
+document the data manipulation that happens along the way so future changes can
+be made with confidence.
+"""
+
+from __future__ import annotations
 
 import os
 from datetime import timedelta
-from typing import Literal, Optional
+from typing import Dict, Iterable, Literal, Optional
 
 import hydra
 import numpy as np
@@ -12,53 +21,71 @@ from hydra import compose, initialize
 from src.forecasting import generate_carbon_cast_96hrs, load_prophet_forecast
 from src.util import DT_INDEX
 
+# ``_DATA_DIR`` is resolved relative to the repository so the module can be
+# imported from both application code and tests without having to rely on the
+# current working directory.
 _DATA_DIR = os.path.join(os.path.dirname(__file__), "../data")
 
 
 class Scenario:
-    def __init__(self,
-                 seed: int,
-                 requests_dataset: str,
-                 region: str,
-                 vp: int,
-                 user_groups_scenario: str,
-                 user_groups: list[dict],
-                 model_qualities: list[str],
-                 machines: list[dict]):
+    """Container describing a full optimisation scenario.
+
+    Parameters are passed directly from the Hydra configuration files used in
+    the experiments.  During initialisation we load the request and carbon
+    intensity data, normalise them for numerical stability, and materialise the
+    machine definitions.
+    """
+
+    def __init__(
+        self,
+        seed: int,
+        requests_dataset: str,
+        region: str,
+        vp: int,
+        user_groups_scenario: str,
+        user_groups: list[dict],
+        model_qualities: list[str],
+        machines: list[dict],
+    ) -> None:
+        # Random numbers are used for synthetic carbon intensity data.  We keep
+        # a dedicated generator so repeated runs with the same configuration are
+        # reproducible.
         self.seed = seed
         self.rng = np.random.default_rng(seed)
 
+        # Configuration identifiers used when serialising results.
         self.requests_dataset = requests_dataset
         self.region = region
-
         self.user_groups_scenario = user_groups_scenario
-        self.user_group_weights = [u["weight"] for u in user_groups]
+        self.vp = vp
 
+        # User group metadata is re-shaped into numpy friendly structures.  The
+        # weights are used to scale demand data per group, while the QoR targets
+        # are mapped to matrices for fast lookups during optimisation.
+        self.user_group_weights = [u["weight"] for u in user_groups]
         self.model_qualities = model_qualities
         self.quality_to_index = {quality: idx for idx, quality in enumerate(model_qualities)}
 
         self.slo_lower = self._build_slo_matrix(user_groups, "slo_lower")
         self.slo_upper = self._build_slo_matrix(user_groups, "slo_upper")
 
-        self.vp = vp
+        # Load the time series backing the scenario.  ``request_scaling_factor``
+        # keeps numerical values in a narrow range to improve solver stability
+        # and is also passed to the machine definitions so their throughput is
+        # scaled consistently.
         self.C, self.C_raw = load_carbon_intensity(region)
-        self.R, self.R_raw, request_scaling_factor = load_requests(requests_dataset, weights=self.user_group_weights)
+        self.R, self.R_raw, request_scaling_factor = load_requests(
+            requests_dataset, weights=self.user_group_weights
+        )
         self.request_scaling_factor = request_scaling_factor
 
-        self.machines = {
-            i: hydra.utils.instantiate(
-                m,
-                request_scaling_factor=request_scaling_factor,
-                quality_to_index=self.quality_to_index,
-                quality_count=len(self.model_qualities),
-            )
-            for i, m in enumerate(machines)
-        }
+        self.machines = self._instantiate_machines(machines, request_scaling_factor)
 
+        # Convenience sets used by the optimisation models to iterate over the
+        # scenario entities.
         self.U = list(range(len(user_groups)))
         self.Q = list(range(len(model_qualities)))
         self.M = list(range(len(machines)))
-
         self.I = list(range(len(DT_INDEX)))  # set of intervals
 
     @property
@@ -66,6 +93,26 @@ class Scenario:
         """Return a descriptive identifier used in file names and logs."""
 
         return f"{self.requests_dataset},{self.region},{self.user_groups_scenario},vp={self.vp}"
+
+    def _instantiate_machines(
+        self, machines: Iterable[Dict], request_scaling_factor: float
+    ) -> dict[int, "Machine"]:
+        """Instantiate machines defined in the configuration.
+
+        Hydra allows us to specify different machine classes in configuration
+        files; we pass the bookkeeping parameters required by :class:`Machine`
+        so that custom classes can consume them as well.
+        """
+
+        return {
+            i: hydra.utils.instantiate(
+                machine_cfg,
+                request_scaling_factor=request_scaling_factor,
+                quality_to_index=self.quality_to_index,
+                quality_count=len(self.model_qualities),
+            )
+            for i, machine_cfg in enumerate(machines)
+        }
 
     @classmethod
     def from_config(cls, cfg):
@@ -107,6 +154,17 @@ class Scenario:
         return np.array([[self.machines[m].performance[q] for m in self.M] for q in self.Q])
 
     def _build_slo_matrix(self, user_groups: list[dict], key: str) -> np.ndarray:
+        """Convert QoR constraints per user group into a matrix.
+
+        Parameters
+        ----------
+        user_groups:
+            The raw configuration objects containing the QoR definitions.
+        key:
+            Either ``"slo_lower"`` or ``"slo_upper"`` specifying which bounds to
+            extract.
+        """
+
         matrix = np.zeros((len(user_groups), len(self.model_qualities)))
         expected_keys = set(self.model_qualities)
         for user_idx, user_group in enumerate(user_groups):
@@ -178,17 +236,22 @@ class Scenario:
 class Machine:
     """Description of a deployable hardware configuration."""
 
-    def __init__(self,
-                 name: str,
-                 performance: dict[str, float],
-                 embedded_carbon: float,
-                 request_scaling_factor: float,  # numerical stability
-                 power_usage: Optional[float] = None,
-                 idle_power_usage: Optional[float] = None,
-                 max_power_usage: Optional[list[float]] = None,
-                 pue: int = 1,
-                 quality_to_index: Optional[dict[str, int]] = None,
-                 quality_count: Optional[int] = None):
+    def __init__(
+        self,
+        name: str,
+        performance: dict[str, float],
+        embedded_carbon: float,
+        request_scaling_factor: float,  # numerical stability
+        power_usage: Optional[float] = None,
+        idle_power_usage: Optional[float] = None,
+        max_power_usage: Optional[list[float]] = None,
+        pue: int = 1,
+        quality_to_index: Optional[dict[str, int]] = None,
+        quality_count: Optional[int] = None,
+    ) -> None:
+        # Throughput is normalised so all optimisation inputs are scaled the
+        # same way.  When ``quality_to_index`` is provided we produce a list that
+        # can be indexed directly by a quality integer.
         self.name = name
         self.performance = self._normalize_performance(
             name,
@@ -197,21 +260,38 @@ class Machine:
             quality_to_index,
             quality_count,
         )
+        # Convert to tonnes of CO₂ equivalent to align with other parts of the
+        # model which operate on that unit.
         self.embedded_carbon = embedded_carbon / 1000000  # gCO₂eq to tCO₂eq
 
-        # load-independent power model
+        # Power models can either be load-independent or load-dependent; both
+        # representations are supported simultaneously and consumers can choose
+        # which accessors to use.
         self._power_usage = power_usage
-
-        # load-dependent power model
         self._idle_power_usage = idle_power_usage
         self._max_power_usage = max_power_usage
-
         self._pue = pue
 
     def load_independent_power_usage(self) -> float:
+        """Return the constant power draw when the simple model is used."""
+
         return self._power_usage
 
     def load_dependent_power_usage(self, q, util: float, n: float = 1) -> float:
+        """Return the dynamic power draw for a given utilisation.
+
+        Parameters
+        ----------
+        q:
+            Index of the model quality to look up in ``max_power_usage``.
+        util:
+            Current utilisation ratio, typically between 0 and 1.
+        n:
+            Exponent applied to the utilisation value.  A value of ``1`` keeps
+            the relationship linear while larger values bias the curve towards
+            high utilisation.
+        """
+
         return self._pue * (self._idle_power_usage + (self._max_power_usage[q] - self._idle_power_usage) * util ** n)
 
     @staticmethod
@@ -220,6 +300,8 @@ class Machine:
                                 request_scaling_factor: float,
                                 quality_to_index: Optional[dict[str, int]],
                                 quality_count: Optional[int]) -> list[float]:
+        """Map performance dictionaries to consistent list representations."""
+
         if quality_to_index is None or quality_count is None:
             return [v * request_scaling_factor for v in performance.values()]
 
@@ -267,7 +349,7 @@ def load_requests(dataset: str, weights: Optional[list[float]] = None) -> tuple[
     return R, R_raw, request_scaling_factor
 
 
-def load_carbon_intensity(region: str):
+def load_carbon_intensity(region: str) -> tuple[np.ndarray, pd.DataFrame]:
     """Load carbon intensity data for ``region`` and return scaled values."""
 
     # adding artificial 2020 bc we do not yet have the data

--- a/tests/test_machine.py
+++ b/tests/test_machine.py
@@ -1,0 +1,49 @@
+"""Unit tests for the :class:`Machine` helper class."""
+
+import pytest
+
+from src.scenario import Machine
+
+
+def test_machine_normalises_performance_with_quality_mapping():
+    machine = Machine(
+        name="accelerator",
+        performance={"high": 20.0, "medium": 10.0},
+        embedded_carbon=5_000.0,
+        request_scaling_factor=0.1,
+        quality_to_index={"medium": 0, "high": 1},
+        quality_count=2,
+        idle_power_usage=1.0,
+        max_power_usage=[1.5, 2.5],
+    )
+
+    assert machine.performance == [pytest.approx(1.0), pytest.approx(2.0)]
+    assert machine.embedded_carbon == pytest.approx(0.005)
+
+
+def test_machine_load_dependent_power_usage():
+    machine = Machine(
+        name="gpu",
+        performance={"standard": 5.0},
+        embedded_carbon=1_000.0,
+        request_scaling_factor=1.0,
+        idle_power_usage=1.0,
+        max_power_usage=[3.0],
+        pue=2,
+    )
+
+    power = machine.load_dependent_power_usage(0, util=0.5)
+    expected = 2 * (1.0 + (3.0 - 1.0) * 0.5)
+    assert power == pytest.approx(expected)
+
+
+def test_machine_unknown_quality_raises():
+    with pytest.raises(ValueError):
+        Machine(
+            name="cpu",
+            performance={"unknown": 1.0},
+            embedded_carbon=1_000.0,
+            request_scaling_factor=1.0,
+            quality_to_index={"standard": 0},
+            quality_count=1,
+        )

--- a/tests/test_scenario.py
+++ b/tests/test_scenario.py
@@ -1,0 +1,118 @@
+"""Unit tests for :mod:`src.scenario`'s :class:`Scenario` class."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from src import scenario as scenario_module
+from src.scenario import Scenario
+from src.util import DT_INDEX
+
+
+@pytest.fixture
+def patched_data(monkeypatch):
+    """Provide deterministic inputs for scenario construction."""
+
+    raw_request_length = len(DT_INDEX) + 8760
+    request_raw = pd.DataFrame(
+        {
+            "ds": pd.date_range(datetime(2020, 1, 1), periods=raw_request_length, freq="h"),
+            "y": np.linspace(1.0, 2.0, raw_request_length),
+        }
+    )
+
+    def fake_load_requests(dataset, weights=None):
+        scaling_factor = 0.5
+        R = np.expand_dims(request_raw["y"].values[-len(DT_INDEX):], axis=1) * scaling_factor
+        if weights:
+            R = np.hstack([R * weight for weight in weights])
+        return R, request_raw, scaling_factor
+
+    carbon_raw = pd.DataFrame(
+        {
+            "ds": pd.date_range(datetime(2020, 1, 1), periods=len(DT_INDEX), freq="h"),
+            "y": np.full(len(DT_INDEX), 200.0),
+        }
+    )
+    carbon_series = carbon_raw["y"].values / 1_000_000
+
+    def fake_load_carbon_intensity(region):
+        return carbon_series, carbon_raw
+
+    def fake_instantiate(config, **kwargs):
+        params = {k: v for k, v in config.items() if k != "_target_"}
+        params.update(kwargs)
+        return scenario_module.Machine(**params)
+
+    monkeypatch.setattr(scenario_module, "load_requests", fake_load_requests)
+    monkeypatch.setattr(scenario_module, "load_carbon_intensity", fake_load_carbon_intensity)
+    monkeypatch.setattr(scenario_module.hydra.utils, "instantiate", fake_instantiate)
+
+
+def build_scenario(requests_dataset: str = "synthetic") -> Scenario:
+    return Scenario(
+        seed=123,
+        requests_dataset=requests_dataset,
+        region="test-region",
+        vp=24,
+        user_groups_scenario="default",
+        user_groups=[
+            {
+                "name": "general",
+                "weight": 1.0,
+                "slo_lower": {"standard": 0.2},
+                "slo_upper": {"standard": 0.8},
+            }
+        ],
+        model_qualities=["standard"],
+        machines=[
+            {
+                "_target_": "src.scenario.Machine",
+                "name": "cpu",
+                "performance": {"standard": 10.0},
+                "embedded_carbon": 1000.0,
+                "power_usage": 1.5,
+                "idle_power_usage": 1.0,
+                "max_power_usage": [2.0],
+            }
+        ],
+    )
+
+
+def test_scenario_initialisation_creates_structures(patched_data):
+    scenario = build_scenario()
+
+    assert scenario.name == "synthetic,test-region,default,vp=24"
+    assert scenario.slo_lower.shape == (1, 1)
+    assert scenario.slo_lower[0, 0] == pytest.approx(0.2)
+    assert scenario.slo_upper[0, 0] == pytest.approx(0.8)
+
+    machine = scenario.machines[0]
+    assert machine.performance == [pytest.approx(5.0)]
+    assert scenario.request_scaling_factor == pytest.approx(0.5)
+
+
+def test_generate_r_hat_static_dataset(patched_data):
+    scenario = build_scenario(requests_dataset="static_dataset")
+
+    forecast = scenario.generate_R_hat(0, kind="yhat")
+    assert np.allclose(forecast, np.ones_like(forecast))
+
+
+def test_build_slo_matrix_missing_quality_raises(patched_data):
+    scenario = build_scenario()
+    with pytest.raises(ValueError):
+        scenario._build_slo_matrix(
+            [
+                {
+                    "name": "incomplete",
+                    "weight": 1.0,
+                    "slo_lower": {},
+                }
+            ],
+            "slo_lower",
+        )


### PR DESCRIPTION
## Summary
- clarify the scenario module by adding documentation, helper methods, and richer comments
- add focused unit tests for the Scenario and Machine helpers to ensure predictable behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68daba4c1eb0832987c1b8b6777f20f7